### PR TITLE
Fix compatibility with gitea/codeberg

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -40,7 +40,7 @@ runs:
           locked="$(echo "$in" | jq -r .path | sed -e "s|^/|.\"|" -e "s/\(.\)\//\1\"\.\"/g" -e "s|\.\"rev$||g")"; \
           old_rev="$(jq -r "$locked.rev" '"$before_flake_lock"')"; \
           new_rev="$(echo "$in" | jq -r .value)"; \
-          path="$(jq -r "$locked | \"https://\(.host // \"github.com\")/\(.owner)/\(.repo)/compare\"" flake.lock)"; \
+          path="$(jq -r "$locked | \"\(.host // (if .type == \"github\" then \"https://github.com/\(.owner)/\(.repo)\" else if .type == \"git\" then .url end end))/compare\"" flake.lock)"; \
           echo "- $path/$old_rev...$new_rev" \
         ' "" >> comment.md
 


### PR DESCRIPTION
Tested locally by hand with the linked PR

```
 ➜ echo "- $path/$old_rev...$new_rev"
- https://codeberg.org/m4rc3l/ifstate.nix/compare/6cd47b88deb0fe5042a4554767e75ca652bb4690...1b1005d18ccebd5045e153f6f8064bab78cd5c1
```

Closes #3